### PR TITLE
refactor: map-json-representation

### DIFF
--- a/assets/levels/entry_point.json
+++ b/assets/levels/entry_point.json
@@ -1,0 +1,22 @@
+{
+  "map": [
+    [1,1,1,1,1,1,1,1],
+    [1,0,0,0,0,0,3,1],
+    [1,0,0,0,0,0,0,1],
+    [1,2,0,0,0,0,0,1],
+    [1,1,1,1,1,1,1,1]
+  ],
+  "objects": {
+    "level_1": {
+      "data": {
+        "type": "level_teleporter",
+        "destination": "example"
+      },
+      "position": {
+        "x": 2,
+        "y": 3
+      },
+      "interaction_type": "all"
+    }
+  }
+}

--- a/assets/levels/example.json
+++ b/assets/levels/example.json
@@ -1,21 +1,25 @@
 {
   "map": [
-        [1,1,1,1,1],
-        [1,0,3,0,1],
-        [1,0,0,0,1],
-        [1,0,2,0,1],
-        [1,1,1,1,1]
+    [1,1,1,1,1],
+    [1,0,3,0,1],
+    [1,0,0,0,1],
+    [1,0,2,0,1],
+    [1,1,1,1,1]
   ],
   "objects": {
     "plaque_1": {
-      "type": "pressure_plate",
+      "data": {
+        "type": "pressure_plate"
+      },
       "position": {
         "x": 2,
         "y": 2
       }
     },
     "door_1": {
-      "type": "door",
+      "data": {
+        "type": "door"
+      },
       "depends_on": [
         "plaque_1"
       ],
@@ -25,45 +29,50 @@
       }
     },
     "teleporter_1": {
-      "type": "teleporter",
-      "ghost_only": true,
+      "data": {
+        "type": "teleporter",
+        "destination": {
+          "x": 7,
+          "y": 3
+        }
+      },
+      "interaction_type": "ghost_only",
       "depends_on": [
         "plaque_1"
       ],
-	  "destination": {
-        "x": 7,
-        "y": 3
-      },
       "position": {
         "x": 3,
         "y": 3
       }
     },
-	"teleporter_2": {
-		"type": "teleporter",
-		"depends_on": [
-		  "plaque_1"
-		],
-		"destination": {
-		  "x": 3,
-		  "y": 3
-		},
-		"position": {
-		  "x": 7,
-		  "y": 3
-		}
-	  },
-	  "lever_1": {
-		"type": "lever",
-		"depends_on": [
-			"plaque_1"
-		  ],
-		  "start_state": false,
-		  "position": {
-			"x": 1,
-			"y": 0
-		  }
-
-	  }
+    "teleporter_2": {
+      "data": {
+        "type": "teleporter",
+        "destination": {
+          "x": 3,
+          "y": 3
+        }
+      },
+      "depends_on": [
+        "plaque_1"
+      ],
+      "position": {
+        "x": 7,
+        "y": 3
+      }
+    },
+    "lever_1": {
+      "data": {
+        "type": "lever"
+      },
+      "depends_on": [
+        "plaque_1"
+      ],
+      "start_state": false,
+      "position": {
+        "x": 1,
+        "y": 0
+      }
+    }
   }
 }

--- a/src/items/populate_items.rs
+++ b/src/items/populate_items.rs
@@ -7,7 +7,7 @@ use crate::items::systems::is_activated::IsActivated;
 use crate::items::systems::people_on::PeopleOn;
 use crate::items::systems::teleport::Teleporter;
 use crate::items::systems::toggle::ToggleInteract;
-use crate::map_parser::map_repr::{ObjectRepr, ObjectType};
+use crate::map_parser::map_repr::{InteractionType, ObjectRepr, ObjectType};
 use crate::math::vec2i::Vec2i;
 use bevy::prelude::*;
 use bevy::utils::HashMap;
@@ -33,8 +33,7 @@ pub fn populate_items(
             ObjectType::PressurePlate => {
                 commands.entity(item).insert(PeopleOn(0));
             }
-            ObjectType::Teleporter => {
-                let destination = object.destination.unwrap();
+            ObjectType::Teleporter { destination } => {
                 commands.entity(item).insert(Teleporter(Vec2i::new(
                     destination.x * 32,
                     destination.y * 32,
@@ -43,14 +42,16 @@ pub fn populate_items(
             ObjectType::Lever => {
                 commands.entity(item).insert(ToggleInteract);
             }
-            _ => {}
+            ObjectType::Door => {}
+            ObjectType::LevelTeleporter { .. } => {}
         };
 
         let item_color = match object.object_type {
             ObjectType::PressurePlate => Color::GREEN,
-            ObjectType::Teleporter => Color::BLUE,
+            ObjectType::Teleporter { .. } => Color::BLUE,
             ObjectType::Lever => Color::YELLOW,
-            _ => Color::RED,
+            ObjectType::Door => Color::MIDNIGHT_BLUE,
+            ObjectType::LevelTeleporter { .. } => Color::BISQUE
         };
 
         commands.entity(item).insert(SpriteBundle {
@@ -64,12 +65,16 @@ pub fn populate_items(
             ..default()
         });
 
-        if (object.ghost_only) {
-            commands.entity(item).insert(GhostOnly);
+        match object.interaction_type {
+            InteractionType::GhostOnly => {
+                commands.entity(item).insert(GhostOnly);
+            }
+            InteractionType::PlayerOnly => {
+                commands.entity(item).insert(PlayerOnly);
+            }
+            InteractionType::All => {}
         }
-        if (object.player_only) {
-            commands.entity(item).insert(PlayerOnly);
-        }
+
         if (object.single_use) {
             commands.entity(item).insert(SingleUse);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,13 +76,13 @@ fn main() {
 
 #[derive(Resource, Default)]
 struct State {
-    level_1_handle: Option<Handle<MapRepr>>,
+    current_level_handle: Option<Handle<MapRepr>>,
     levels_loaded: bool,
 }
 
 fn load_levels(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResMut<State>) {
     commands.spawn(Camera2dBundle::default());
-    state.level_1_handle = Some(asset_server.load("levels/example.json"));
+    state.current_level_handle = Some(asset_server.load("levels/example.json"));
 }
 
 fn check_levels_loaded_system(
@@ -94,13 +94,13 @@ fn check_levels_loaded_system(
         return;
     }
 
-    let level_example = custom_assets.get(state.level_1_handle.as_ref().unwrap());
+    let level_example = custom_assets.get(state.current_level_handle.as_ref().unwrap());
     if level_example.is_none() {
         return;
     }
     state.levels_loaded = true;
     let level_example = custom_assets
-        .get(state.level_1_handle.as_ref().unwrap())
+        .get(state.current_level_handle.as_ref().unwrap())
         .unwrap();
 
     let mut world_map = Map::default();

--- a/src/map_parser/map_repr.rs
+++ b/src/map_parser/map_repr.rs
@@ -54,28 +54,39 @@ pub enum BackgroundType {
     End = 3,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct ObjectRepr {
     pub position: Vec2i,
-    pub destination: Option<Vec2i>,
-
-    #[serde(rename = "type")]
+    #[serde(default)]
+    pub interaction_type: InteractionType,
+    #[serde(rename = "data")]
     pub object_type: ObjectType,
     #[serde(default)]
     pub depends_on: Vec<String>,
     #[serde(default)]
-    pub ghost_only: bool,
-    #[serde(default)]
-    pub player_only: bool,
-    #[serde(default)]
     pub single_use: bool,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "snake_case")]
+pub enum InteractionType {
+    #[default]
+    All,
+    GhostOnly,
+    PlayerOnly,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "type")]
 pub enum ObjectType {
     PressurePlate,
     Door,
-    Teleporter,
+    Teleporter {
+        destination: Vec2i,
+    },
+    LevelTeleporter {
+        destination: String,
+    },
     Lever,
 }


### PR DESCRIPTION
enum ObjectType avec des datas.
Pour éviter d'avoir des options partout
enum InteractionType pour ghost et player only